### PR TITLE
Use github-pages gem instead of referencing jekyll directly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,8 @@
 source 'https://rubygems.org'
 
-gem 'jekyll', '~>2.0'
+require 'json'
+require 'open-uri'
+versions = JSON.parse(open('https://pages.github.com/versions.json').read)
+
+gem 'github-pages', versions['github-pages']
 gem 'jekyll-redirect-from'


### PR DESCRIPTION
I've been reading over the Jekyll and GitHub Pages docs to get my head around how to use this. One thing both stress is that [it’s best practice to use the `github-pages` gem](http://jekyllrb.com/docs/github-pages/), because that will help resolve dependency issues between the gems that GitHub runs and the gems we run locally.
